### PR TITLE
add compiler macro for alpine linux

### DIFF
--- a/AdsLib/wrap_socket.h
+++ b/AdsLib/wrap_socket.h
@@ -25,7 +25,7 @@
 
 #include <cstdint>
 
-#if defined(__gnu_linux__) || defined(__linux__) || defined(__APPLE__)|| defined(__CYGWIN__)
+#if defined(__gnu_linux__) || defined(__linux__) || defined(__APPLE__) || defined(__CYGWIN__)
 #include <arpa/inet.h>
 #include <netinet/in.h>
 #include <netinet/tcp.h>

--- a/AdsLib/wrap_socket.h
+++ b/AdsLib/wrap_socket.h
@@ -25,7 +25,7 @@
 
 #include <cstdint>
 
-#if defined(__gnu_linux__) || defined(__APPLE__) || defined(__CYGWIN__)
+#if defined(__gnu_linux__) || defined(__linux__) || defined(__APPLE__)|| defined(__CYGWIN__)
 #include <arpa/inet.h>
 #include <netinet/in.h>
 #include <netinet/tcp.h>


### PR DESCRIPTION
gcc on Alpine doesn't define `__gnu_linux__` only `__linux`, `__linux__` and `linux`.

Alpine Linux is used in Hass.io (see issue https://github.com/home-assistant/hassio-homeassistant/issues/25)